### PR TITLE
feat: implement get all schedules endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 gem "jsonapi-serializer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -245,6 +247,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.1.4)
   rspec-rails
   shoulda-matchers

--- a/app/controllers/api/v1/schedules_controller.rb
+++ b/app/controllers/api/v1/schedules_controller.rb
@@ -1,3 +1,6 @@
 class Api::V1::SchedulesController < ApplicationController
-  
+  def index
+    schedules = Schedule.all
+    render json: ScheduleSerializer.new(Schedule.all)
+  end
 end

--- a/app/serializers/schedule_serializer.rb
+++ b/app/serializers/schedule_serializer.rb
@@ -1,0 +1,4 @@
+class ScheduleSerializer
+  include JSONAPI::Serializer
+  attributes :name, :description, :shows
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
+  config.hosts << 'localhost'
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/spec/requests/schedule_request_spec.rb
+++ b/spec/requests/schedule_request_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'Schedule Endpoints', type: :request do
+  describe 'GET all schedules' do
+    it 'returns all schedules' do
+      get 'http://localhost:3000/api/v1/schedules'
+      schedules = JSON.parse(response.body, symbolize_names:true)
+
+      expect(response).to have_http_status(:ok)
+      expect(schedules).to have_key(:data)
+      expect(schedules[:data]).to be_an(Array)
+      expect(schedules[:data][0]).to have_key(:id)
+      expect(schedules[:data][0]).to have_key(:type)
+      expect(schedules[:data][0][:type]).to eq('schedule')
+      expect(schedules[:data][0]).to have_key(:attributes)
+      expect(schedules[:data][0][:attributes]).to have_key(:name)
+      expect(schedules[:data][0][:attributes]).to have_key(:description)
+      expect(schedules[:data][0][:attributes]).to have_key(:shows)
+      expect(schedules[:data][0][:attributes][:shows]).to be_an(Array)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the schedules index endpoint, including adding the index method to the controller, creating a schedules serializer, and testing the endpoint. 