### PR TITLE
feat: format attendee schedule serializer and reseed database with schedule shows

### DIFF
--- a/app/serializers/attendee_schedule_serializer.rb
+++ b/app/serializers/attendee_schedule_serializer.rb
@@ -8,13 +8,29 @@ class AttendeeScheduleSerializer
           attendee_id: attendee.id,
           type: 'attendee schedule',
           attributes: {
+            attendee_name: "#{attendee.first_name} #{attendee.last_name}",
+            attendee_email: attendee.email,
             schedule: {
               schedule_name: attendee_schedule.name,
-              schedule_description: attendee_schedule.description
-            }
-            schedule_shows: {
-              
-            }
+              schedule_description: attendee_schedule.description,
+              shows: schedule_shows.map do |show|
+                {
+                  id: show.id.to_s,
+                  artist_name: show.artist_name,
+                  genre: show.genre,
+                  location: show.location,
+                  start_time: show.start_time, 
+                  end_time: show.end_time
+                }
+              end,
+            },
+            other_schedule_attendees: schedule_attendees.map do |other_attendee|
+              {
+                attendee_id: other_attendee.id,
+                attendee_name: "#{other_attendee.first_name} #{other_attendee.last_name}",
+                attendee_email: other_attendee.email
+              }
+            end
           }
         }
       ]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,9 +10,9 @@ require 'faker'
 #   end
 
 ScheduleShow.destroy_all
-Show.destroy_all
-Schedule.destroy_all
 Attendee.destroy_all
+Schedule.destroy_all
+Show.destroy_all
 
 festival_dates = [
   Date.new(2025, 3, 14),
@@ -68,4 +68,14 @@ end
     start_time: start_time,
     end_time: end_time
   )
+end
+
+Schedule.all.each do |schedule|
+  random_shows = Show.all.sample(rand(3..7))
+  random_shows.each do |show|
+    ScheduleShow.find_or_create_by(
+      schedule: schedule,
+      show: show
+    )
+  end
 end


### PR DESCRIPTION
This PR formats the attendee schedule serializer to display attendee schedule information. It also reseeds the database to associate shows with schedules in the schedule_shows table. 